### PR TITLE
Go で HTTP Server の実装を試す

### DIFF
--- a/go/tour-of-go/http_middleware/.air.toml
+++ b/go/tour-of-go/http_middleware/.air.toml
@@ -1,0 +1,46 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/go/tour-of-go/http_middleware/compose.yml
+++ b/go/tour-of-go/http_middleware/compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: default_db
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./testdata/init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/go/tour-of-go/http_middleware/go.mod
+++ b/go/tour-of-go/http_middleware/go.mod
@@ -1,3 +1,5 @@
 module github.com/kudoas/enjoy-middleware
 
 go 1.21.2
+
+require github.com/justinas/alice v1.2.0

--- a/go/tour-of-go/http_middleware/go.mod
+++ b/go/tour-of-go/http_middleware/go.mod
@@ -1,0 +1,3 @@
+module github.com/kudoas/enjoy-middleware
+
+go 1.21.2

--- a/go/tour-of-go/http_middleware/go.mod
+++ b/go/tour-of-go/http_middleware/go.mod
@@ -3,3 +3,8 @@ module github.com/kudoas/enjoy-middleware
 go 1.21.2
 
 require github.com/justinas/alice v1.2.0
+
+require (
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
+)

--- a/go/tour-of-go/http_middleware/go.mod
+++ b/go/tour-of-go/http_middleware/go.mod
@@ -5,6 +5,7 @@ go 1.21.2
 require github.com/justinas/alice v1.2.0
 
 require (
+	github.com/lib/pq v1.10.9 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 )

--- a/go/tour-of-go/http_middleware/go.sum
+++ b/go/tour-of-go/http_middleware/go.sum
@@ -1,0 +1,2 @@
+github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=

--- a/go/tour-of-go/http_middleware/go.sum
+++ b/go/tour-of-go/http_middleware/go.sum
@@ -1,5 +1,7 @@
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=

--- a/go/tour-of-go/http_middleware/go.sum
+++ b/go/tour-of-go/http_middleware/go.sum
@@ -1,2 +1,6 @@
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
+go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -33,7 +33,11 @@ func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	chain := alice.New(middleware.Authentication, middleware.Logger, middleware.Header)
+	logger, err := middleware.NewLogger()
+	if err != nil {
+		log.Fatalln(err)
+	}
+	chain := alice.New(middleware.Authentication, middleware.Logger(logger), middleware.Header)
 
 	http.Handle("/v1/hello", chain.Then(http.HandlerFunc(HelloHandler)))
 	http.Handle("/v1/time", chain.Then(http.HandlerFunc(CurrentTimeHandler)))

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -18,7 +18,7 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 
 func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 	curTime := time.Now().Format(time.Kitchen)
-	msg := fmt.Sprintf(`{"message": "the current time is %v"`, curTime)
+	msg := fmt.Sprintf(`{"message": "the current time is %v"}`, curTime)
 	b, _ := json.Marshal(msg)
 	w.Write(b)
 }

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/justinas/alice"
 	"github.com/kudoas/enjoy-middleware/middleware"
+	_ "github.com/lib/pq"
 )
 
 type Response struct {
@@ -33,6 +35,12 @@ func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	db, err := sql.Open("postgres", "host=localhost port=5432 dbname=default_db user=postgres password=default_pass sslmode=disable")
+	if err != nil {
+		log.Fatalf("データベースへの接続に失敗しました: %v", err)
+	}
+	defer db.Close()
+
 	logger, err := middleware.NewLogger()
 	if err != nil {
 		log.Fatalln(err)

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -19,7 +19,7 @@ func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func middlewareWrapper(f http.HandlerFunc) http.HandlerFunc {
-	return middleware.Logger(middleware.Header(f))
+	return middleware.Authentication(middleware.Logger(middleware.Header(f)))
 }
 
 func main() {

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justinas/alice"
 	"github.com/kudoas/enjoy-middleware/middleware"
 	"github.com/kudoas/enjoy-middleware/model"
+	"github.com/kudoas/enjoy-middleware/response"
 	_ "github.com/lib/pq"
 )
 
@@ -29,10 +30,22 @@ func GetUserHandler(db *sql.DB) http.HandlerFunc {
 		users, err := model.FetchUser(db)
 		if err != nil {
 			log.Fatalf("failed to fetch user: %v", err)
+			response.InternalServerError(w)
+			return
 		}
 
-		b, _ := json.Marshal(users)
-		_, _ = w.Write(b)
+		b, err := json.Marshal(users)
+		if err != nil {
+			log.Fatalf("failed to marshal user: %v", err)
+			response.InternalServerError(w)
+			return
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			log.Fatalf("failed to write response: %v", err)
+			response.InternalServerError(w)
+			return
+		}
 
 		return
 	}

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -20,7 +20,7 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 		Message: "hello world",
 	}
 	b, _ := json.Marshal(res)
-	w.Write(b)
+	_, _ = w.Write(b)
 }
 
 func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +29,7 @@ func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 		Message: fmt.Sprintf("the current time is %v", curTime),
 	}
 	b, _ := json.Marshal(res)
-	w.Write(b)
+	_, _ = w.Write(b)
 }
 
 func main() {

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -30,5 +30,7 @@ func main() {
 	http.Handle("/v1/time", chain.Then(http.HandlerFunc(CurrentTimeHandler)))
 
 	log.Printf("server is listening at %s", ":8080")
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type Logger struct {
+	m *http.ServeMux
+}
+
+func (l *Logger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	l.m.ServeHTTP(w, r)
+	log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
+}
+
+func NewLogger(m *http.ServeMux) *Logger { return &Logger{m} }
+
+type ResponseHeader struct {
+	m           *http.ServeMux
+	headerName  string
+	headerValue string
+}
+
+func (rh *ResponseHeader) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add(rh.headerName, rh.headerValue)
+	log.Println(rh.headerName, rh.headerValue)
+	rh.m.ServeHTTP(w, r)
+}
+
+func NewResponseHeader(m *http.ServeMux, name string, value string) *ResponseHeader {
+	return &ResponseHeader{m: m, headerName: name, headerValue: value}
+}
+
+func HelloHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Hello, World!"))
+}
+
+func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
+	curTime := time.Now().Format(time.Kitchen)
+	w.Write([]byte(fmt.Sprintf("the current time is %v", curTime)))
+}
+
+func main() {
+	http.HandleFunc("/v1/hello", HelloHandler)
+	http.HandleFunc("/v1/time", CurrentTimeHandler)
+
+	wrapMux := NewLogger(NewResponseHeader(http.DefaultServeMux, "X-My-Header", "my header value").m)
+
+	log.Printf("server is listening at %s", ":8080")
+	log.Fatal(http.ListenAndServe(":8080", wrapMux))
+}

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -11,15 +11,24 @@ import (
 	"github.com/kudoas/enjoy-middleware/middleware"
 )
 
+type Response struct {
+	Message string `json:"message"`
+}
+
 func HelloHandler(w http.ResponseWriter, r *http.Request) {
-	b, _ := json.Marshal(`{"message": "Hello, World!"}`)
+	res := Response{
+		Message: "hello world",
+	}
+	b, _ := json.Marshal(res)
 	w.Write(b)
 }
 
 func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 	curTime := time.Now().Format(time.Kitchen)
-	msg := fmt.Sprintf(`{"message": "the current time is %v"}`, curTime)
-	b, _ := json.Marshal(msg)
+	res := Response{
+		Message: fmt.Sprintf("the current time is %v", curTime),
+	}
+	b, _ := json.Marshal(res)
 	w.Write(b)
 }
 

--- a/go/tour-of-go/http_middleware/main.go
+++ b/go/tour-of-go/http_middleware/main.go
@@ -5,35 +5,9 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/kudoas/enjoy-middleware/middleware"
 )
-
-type Logger struct {
-	m *http.ServeMux
-}
-
-func (l *Logger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	start := time.Now()
-	l.m.ServeHTTP(w, r)
-	log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
-}
-
-func NewLogger(m *http.ServeMux) *Logger { return &Logger{m} }
-
-type ResponseHeader struct {
-	m           *http.ServeMux
-	headerName  string
-	headerValue string
-}
-
-func (rh *ResponseHeader) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add(rh.headerName, rh.headerValue)
-	log.Println(rh.headerName, rh.headerValue)
-	rh.m.ServeHTTP(w, r)
-}
-
-func NewResponseHeader(m *http.ServeMux, name string, value string) *ResponseHeader {
-	return &ResponseHeader{m: m, headerName: name, headerValue: value}
-}
 
 func HelloHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Hello, World!"))
@@ -44,12 +18,14 @@ func CurrentTimeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(fmt.Sprintf("the current time is %v", curTime)))
 }
 
-func main() {
-	http.HandleFunc("/v1/hello", HelloHandler)
-	http.HandleFunc("/v1/time", CurrentTimeHandler)
+func middlewareWrapper(f http.HandlerFunc) http.HandlerFunc {
+	return middleware.Logger(middleware.Header(f))
+}
 
-	wrapMux := NewLogger(NewResponseHeader(http.DefaultServeMux, "X-My-Header", "my header value").m)
+func main() {
+	http.HandleFunc("/v1/hello", middlewareWrapper(HelloHandler))
+	http.HandleFunc("/v1/time", middlewareWrapper(CurrentTimeHandler))
 
 	log.Printf("server is listening at %s", ":8080")
-	log.Fatal(http.ListenAndServe(":8080", wrapMux))
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/go/tour-of-go/http_middleware/middleware/authentication.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication.go
@@ -30,5 +30,5 @@ func writeForbiddenResponse(w http.ResponseWriter) {
 		Message: "forbidden",
 	}
 	b, _ := json.Marshal(errorMessage)
-	w.Write(b)
+	_, _ = w.Write(b)
 }

--- a/go/tour-of-go/http_middleware/middleware/authentication.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication.go
@@ -1,16 +1,28 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 )
 
 func Authentication(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if host := r.Host; host == "public.example" {
-			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte(`{"message": "forbidden"}`))
+		if isPublicHost(r.Host) {
+			writeForbiddenResponse(w)
 			return
 		}
+
 		next.ServeHTTP(w, r)
 	})
+}
+
+func isPublicHost(host string) bool {
+	return host == "public.example"
+}
+
+func writeForbiddenResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusForbidden)
+	errorMessage := `{"message": "forbidden"}`
+	b, _ := json.Marshal(errorMessage)
+	w.Write(b)
 }

--- a/go/tour-of-go/http_middleware/middleware/authentication.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+func Authentication(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if host := r.Host; host == "public.example" {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"message": "forbidden"}`))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/go/tour-of-go/http_middleware/middleware/authentication.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication.go
@@ -5,6 +5,10 @@ import (
 	"net/http"
 )
 
+type ErrorResponse struct {
+	Message string `json:"message"`
+}
+
 func Authentication(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isPublicHost(r.Host) {
@@ -22,7 +26,9 @@ func isPublicHost(host string) bool {
 
 func writeForbiddenResponse(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusForbidden)
-	errorMessage := `{"message": "forbidden"}`
+	errorMessage := ErrorResponse{
+		Message: "forbidden",
+	}
 	b, _ := json.Marshal(errorMessage)
 	w.Write(b)
 }

--- a/go/tour-of-go/http_middleware/middleware/authentication_test.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication_test.go
@@ -1,0 +1,64 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kudoas/enjoy-middleware/middleware"
+)
+
+func TestAuthentication(t *testing.T) {
+	testCase := []struct {
+		name               string
+		host               string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Authorized / valid host header",
+			host:               "admin.internal",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "UnAuthorized / invalid host header",
+			host:               "public.example",
+			expectedStatusCode: http.StatusForbidden,
+		},
+	}
+
+	testHandler := setupTestHandler(t)
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = tc.host
+			rec := httptest.NewRecorder()
+
+			testHandler.ServeHTTP(rec, req)
+
+			switch tc.host {
+			case "public.example":
+				if rec.Code == http.StatusOK {
+					t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
+				}
+				if expectedBody := `{"message": "forbidden"}`; rec.Body.String() != expectedBody {
+					t.Errorf("Expected body %s, got %s", expectedBody, rec.Body.String())
+				}
+			case "admin.internal":
+				if rec.Code == http.StatusForbidden {
+					t.Errorf("Expected status code %d, got %d", http.StatusForbidden, rec.Code)
+				}
+			}
+		})
+	}
+}
+
+func setupTestHandler(t *testing.T) http.Handler {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message": "success"}`))
+	})
+
+	return middleware.Authentication(handler)
+}

--- a/go/tour-of-go/http_middleware/middleware/authentication_test.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication_test.go
@@ -43,9 +43,10 @@ func TestAuthentication(t *testing.T) {
 				if rec.Code == http.StatusOK {
 					t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
 				}
-				body, _ := json.Marshal(`{"message": "forbidden"}`)
-				if expectedBody := body; !bytes.Equal(rec.Body.Bytes(), expectedBody) {
-					t.Errorf("Expected body %s, got %s", expectedBody, rec.Body.String())
+				var resBody middleware.ErrorResponse
+				json.NewDecoder(bytes.NewReader(rec.Body.Bytes())).Decode(&resBody)
+				if resBody.Message != "forbidden" {
+					t.Errorf("Expected response body %s, got %s", "forbidden", resBody.Message)
 				}
 			case "admin.internal":
 				if rec.Code == http.StatusForbidden {

--- a/go/tour-of-go/http_middleware/middleware/authentication_test.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication_test.go
@@ -1,6 +1,8 @@
 package middleware_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,7 +43,8 @@ func TestAuthentication(t *testing.T) {
 				if rec.Code == http.StatusOK {
 					t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
 				}
-				if expectedBody := `{"message": "forbidden"}`; rec.Body.String() != expectedBody {
+				body, _ := json.Marshal(`{"message": "forbidden"}`)
+				if expectedBody := body; !bytes.Equal(rec.Body.Bytes(), expectedBody) {
 					t.Errorf("Expected body %s, got %s", expectedBody, rec.Body.String())
 				}
 			case "admin.internal":
@@ -57,7 +60,8 @@ func setupTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"message": "success"}`))
+		body, _ := json.Marshal(`{"message": "success"}`)
+		w.Write(body)
 	})
 
 	return middleware.Authentication(handler)

--- a/go/tour-of-go/http_middleware/middleware/authentication_test.go
+++ b/go/tour-of-go/http_middleware/middleware/authentication_test.go
@@ -61,8 +61,6 @@ func setupTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		body, _ := json.Marshal(`{"message": "success"}`)
-		w.Write(body)
 	})
 
 	return middleware.Authentication(handler)

--- a/go/tour-of-go/http_middleware/middleware/header.go
+++ b/go/tour-of-go/http_middleware/middleware/header.go
@@ -1,0 +1,10 @@
+package middleware
+
+import "net/http"
+
+func Header(next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-custom-header", "my-value")
+		next.ServeHTTP(w, r)
+	}
+}

--- a/go/tour-of-go/http_middleware/middleware/header.go
+++ b/go/tour-of-go/http_middleware/middleware/header.go
@@ -8,7 +8,8 @@ import (
 func Header(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Println("middleware header")
-		w.Header().Add("X-custom-header", "my-value")
+		w.Header().Set("content-type", "application/json")
+		w.Header().Set("x-custom-value", "my-value")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/go/tour-of-go/http_middleware/middleware/header.go
+++ b/go/tour-of-go/http_middleware/middleware/header.go
@@ -1,13 +1,11 @@
 package middleware
 
 import (
-	"log"
 	"net/http"
 )
 
 func Header(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Println("middleware header")
 		w.Header().Set("content-type", "application/json")
 		w.Header().Set("x-custom-value", "my-value")
 		next.ServeHTTP(w, r)

--- a/go/tour-of-go/http_middleware/middleware/header.go
+++ b/go/tour-of-go/http_middleware/middleware/header.go
@@ -1,10 +1,14 @@
 package middleware
 
-import "net/http"
+import (
+	"log"
+	"net/http"
+)
 
-func Header(next http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func Header(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Println("middleware header")
 		w.Header().Add("X-custom-header", "my-value")
 		next.ServeHTTP(w, r)
-	}
+	})
 }

--- a/go/tour-of-go/http_middleware/middleware/logger.go
+++ b/go/tour-of-go/http_middleware/middleware/logger.go
@@ -4,19 +4,21 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"go.uber.org/zap"
 )
 
-// trace を OpenTelemetry で送る
 func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Println("middleware logger")
 		start := time.Now()
-		// defer func() {
-		// 	if errClose := r.Body.Close(); errClose != nil {
-		// 		log.Println("failed to close body, should never happen")
-		// 	}
-		// }()
+		logger, err := zap.NewProduction()
+		if err != nil {
+			log.Fatalf("can't initialize zap logger: %v", err)
+		}
+		defer logger.Sync()
+		logger.Info("fetch URL",
+			zap.Duration("time", time.Since(start)),
+		)
 		next.ServeHTTP(w, r)
-		log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
 	})
 }

--- a/go/tour-of-go/http_middleware/middleware/logger.go
+++ b/go/tour-of-go/http_middleware/middleware/logger.go
@@ -15,7 +15,7 @@ func Logger(next http.Handler) http.Handler {
 		if err != nil {
 			log.Fatalf("can't initialize zap logger: %v", err)
 		}
-		defer logger.Sync()
+		// defer logger.Sync() Probably not needed
 		logger.Info("fetch URL",
 			zap.Duration("time", time.Since(start)),
 		)

--- a/go/tour-of-go/http_middleware/middleware/logger.go
+++ b/go/tour-of-go/http_middleware/middleware/logger.go
@@ -6,10 +6,16 @@ import (
 	"time"
 )
 
-func Logger(next http.Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func Logger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Println("middleware logger")
 		start := time.Now()
+		// defer func() {
+		// 	if errClose := r.Body.Close(); errClose != nil {
+		// 		log.Println("failed to close body, should never happen")
+		// 	}
+		// }()
 		next.ServeHTTP(w, r)
 		log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
-	}
+	})
 }

--- a/go/tour-of-go/http_middleware/middleware/logger.go
+++ b/go/tour-of-go/http_middleware/middleware/logger.go
@@ -1,24 +1,33 @@
 package middleware
 
 import (
-	"log"
 	"net/http"
 	"time"
 
 	"go.uber.org/zap"
 )
 
-func Logger(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		logger, err := zap.NewProduction()
-		if err != nil {
-			log.Fatalf("can't initialize zap logger: %v", err)
-		}
-		// defer logger.Sync() Probably not needed
-		logger.Info("fetch URL",
-			zap.Duration("time", time.Since(start)),
-		)
-		next.ServeHTTP(w, r)
-	})
+// prevent logger initialization every request
+func NewLogger() (*zap.Logger, error) {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return nil, err
+	}
+
+	return logger, nil
+}
+
+func Logger(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			next.ServeHTTP(w, r)
+			logger.Info("request completed",
+				zap.String("method", r.Method),
+				zap.String("host", r.Host),
+				zap.String("url", r.URL.String()),
+				zap.Duration("duration", time.Since(start)),
+			)
+		})
+	}
 }

--- a/go/tour-of-go/http_middleware/middleware/logger.go
+++ b/go/tour-of-go/http_middleware/middleware/logger.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// trace を OpenTelemetry で送る
 func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Println("middleware logger")

--- a/go/tour-of-go/http_middleware/middleware/logger.go
+++ b/go/tour-of-go/http_middleware/middleware/logger.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+func Logger(next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
+	}
+}

--- a/go/tour-of-go/http_middleware/model/user.go
+++ b/go/tour-of-go/http_middleware/model/user.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"database/sql"
+)
+
+type User struct {
+	ID   int
+	Name string
+}
+
+var users []User
+
+func FetchUser(db *sql.DB) (*[]User, error) {
+	rows, err := db.Query("SELECT id, name FROM users")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var u User
+		err = rows.Scan(&u.ID, &u.Name)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &users, nil
+}

--- a/go/tour-of-go/http_middleware/response/response.go
+++ b/go/tour-of-go/http_middleware/response/response.go
@@ -1,0 +1,21 @@
+// internal server error
+
+package response
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ErrorResponse struct {
+	Message string `json:"message"`
+}
+
+func InternalServerError(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusInternalServerError)
+	errorMessage := ErrorResponse{
+		Message: "internal server error",
+	}
+	b, _ := json.Marshal(errorMessage)
+	_, _ = w.Write(b)
+}

--- a/go/tour-of-go/http_middleware/testdata/init.sql
+++ b/go/tour-of-go/http_middleware/testdata/init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE
+    users (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255) NOT NULL
+    );
+
+-- default data
+INSERT INTO users (name) VALUES ('admin master');
+
+INSERT INTO users (name) VALUES ('normal star');
+
+INSERT INTO users (name) VALUES ('simple fisher');


### PR DESCRIPTION
実装：https://github.com/kudoas/sandbox/tree/2b7691630814576ce4f918d2f350a075c96a5622/go/tour-of-go/http_middleware

- やったこと
  - JSONを返却するAPIサーバーの実装
  - host ヘッダーによって 403を返す認証用 Middleware の実装
    - この Middleware はテストも書いた
  - ログ出力は zap を利用
  - Middleware のチェーン（ 自前で実装するより https://github.com/justinas/alice を利用した、軽量なのでコード見ても何しているかわかりやすい）
  - DBからデータをSELECTするエンドポイントを用意して、結果を構造体に紐付け